### PR TITLE
[codex] use system color scheme

### DIFF
--- a/layouts/base.eta
+++ b/layouts/base.eta
@@ -6,53 +6,6 @@
     <title><%= it.siteTitle === it.title ? it.title : `${it.title} | ${it.siteTitle}` %></title>
     <meta name="description" content="<%= it.summary %>">
     <link rel="stylesheet" href="/style.css">
-    <script>
-      (() => {
-        const storageKey = "theme";
-        const root = document.documentElement;
-
-        const getStoredTheme = () => localStorage.getItem(storageKey) || "system";
-        const getSystemTheme = () =>
-          window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light";
-
-        const applyTheme = (storedTheme) => {
-          root.dataset.theme = storedTheme === "system" ? getSystemTheme() : storedTheme;
-        };
-
-        applyTheme(getStoredTheme());
-
-        document.addEventListener("DOMContentLoaded", () => {
-          const selector = document.querySelector(".theme-selector");
-          const currentTheme = getStoredTheme();
-
-          if (selector) {
-            selector.removeAttribute("hidden");
-            document.querySelectorAll('input[name="theme"]').forEach((input) => {
-              input.checked = input.value === currentTheme;
-              input.addEventListener("change", () => {
-                if (input.value === "system") {
-                  localStorage.removeItem(storageKey);
-                } else {
-                  localStorage.setItem(storageKey, input.value);
-                }
-                applyTheme(getStoredTheme());
-              });
-            });
-          }
-
-          if (window.matchMedia) {
-            const media = window.matchMedia("(prefers-color-scheme: dark)");
-            media.addEventListener("change", () => {
-              if (getStoredTheme() === "system") {
-                applyTheme("system");
-              }
-            });
-          }
-        });
-      })();
-    </script>
   </head>
   <body>
     <main>
@@ -60,12 +13,6 @@
     </main>
 
     <footer>
-      <p class="theme-selector" hidden>
-        Color scheme:
-        <label><input type="radio" name="theme" value="system"> <span>auto</span></label>,
-        <label><input type="radio" name="theme" value="light"> <span>light</span></label>,
-        <label><input type="radio" name="theme" value="dark"> <span>dark</span></label>.
-      </p>
       <p class="footer-license">
         Content licensed under the <a href="https://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
       </p>

--- a/static/reference/index.html
+++ b/static/reference/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -15,26 +15,8 @@
         --accent-muted: #6b7f5a;
       }
 
-      :root[data-theme="light"] {
-        --bg: #f5f5f2;
-        --text: #1f1f1f;
-        --text-secondary: #6b6e73;
-        --border: #dadada;
-        --accent: #2f5d8c;
-        --accent-muted: #6b7f5a;
-      }
-
-      :root[data-theme="dark"] {
-        --bg: #1b1d20;
-        --text: #ededeb;
-        --text-secondary: #a7a9ad;
-        --border: #34383c;
-        --accent: #4a78a8;
-        --accent-muted: #6b7f5a;
-      }
-
       @media (prefers-color-scheme: dark) {
-        :root:not([data-theme]) {
+        :root {
           --bg: #1b1d20;
           --text: #ededeb;
           --text-secondary: #a7a9ad;
@@ -184,30 +166,6 @@
       .muted-link {
         color: var(--accent-muted);
       }
-
-      p.theme-selector {
-        color: var(--text-secondary);
-        font-size: 0.9rem;
-        margin: 1.5rem 0 0;
-      }
-
-      p.theme-selector input {
-        display: none;
-      }
-
-      p.theme-selector label {
-        cursor: pointer;
-        margin: 0;
-        text-decoration: none;
-      }
-
-      p.theme-selector label:hover {
-        text-decoration: underline;
-      }
-
-      p.theme-selector input:checked + span {
-        text-decoration: underline;
-      }
     </style>
   </head>
   <body>
@@ -220,34 +178,6 @@
         <a href="#">Projects</a>
         <a href="#">About</a>
       </nav>
-      <p class="theme-selector" hidden>
-        Color scheme:
-        <label><input type="radio" name="theme" value="system" /> <span>auto</span></label>,
-        <label><input type="radio" name="theme" value="light" /> <span>light</span></label>,
-        <label><input type="radio" name="theme" value="dark" /> <span>dark</span></label>.
-        <script>
-          const themeKey = "theme-preference";
-          const storedTheme = localStorage.getItem(themeKey) || "system";
-
-          const selectTheme = (value) => {
-            if (value === "system") {
-              document.documentElement.removeAttribute("data-theme");
-            } else {
-              document.documentElement.setAttribute("data-theme", value);
-            }
-            localStorage.setItem(themeKey, value);
-          };
-
-          document.querySelector(".theme-selector").removeAttribute("hidden");
-          document.querySelectorAll('input[name="theme"]').forEach((input) => {
-            input.checked = input.value === storedTheme;
-            input.addEventListener("change", () => {
-              selectTheme(input.value);
-            });
-          });
-          selectTheme(storedTheme);
-        </script>
-      </p>
     </header>
 
     <main>
@@ -256,16 +186,18 @@
         <h2>The Quiet Authority of Neutral Space</h2>
         <p class="meta">January 30, 2026 · 7 min read</p>
         <p>
-          A neutral palette is not an absence; it is a decision. It limits options
-          to make clarity unavoidable. In practice, it means restraint: no gradients,
-          no decorative shadows, and a system that reads like a well-edited report.
+          A neutral palette is not an absence; it is a decision. It limits
+          options to make clarity unavoidable. In practice, it means restraint:
+          no gradients, no decorative shadows, and a system that reads like a
+          well-edited report.
         </p>
         <p>
-          This sample theme aims for the feeling of a government PDF at midnight —
-          clear, calm, and built for concentration.
+          This sample theme aims for the feeling of a government PDF at midnight
+          — clear, calm, and built for concentration.
         </p>
         <p class="accent-block">
-          “International Style is less a look and more a commitment to legibility.”
+          “International Style is less a look and more a commitment to
+          legibility.”
         </p>
       </section>
 
@@ -288,11 +220,15 @@
           <div class="swatch-row">
             <div class="swatch">
               <div class="swatch-color" style="background: #7b8672"></div>
-              <div class="swatch-label">Cooler, grayer olive (sage) — #7B8672</div>
+              <div class="swatch-label">
+                Cooler, grayer olive (sage) — #7B8672
+              </div>
             </div>
             <div class="swatch">
               <div class="swatch-color" style="background: #59624f"></div>
-              <div class="swatch-label">Deeper architectural olive — #59624F</div>
+              <div class="swatch-label">
+                Deeper architectural olive — #59624F
+              </div>
             </div>
           </div>
         </div>
@@ -305,8 +241,8 @@
           <p class="tag">Notebook</p>
           <h3>Glass, Steel, Paper</h3>
           <p>
-            Tone is built from contrast. Off-white paper, charcoal text, and a muted
-            blue accent. Everything else is structure.
+            Tone is built from contrast. Off-white paper, charcoal text, and a
+            muted blue accent. Everything else is structure.
           </p>
           <a href="#">Continue reading</a>
         </article>
@@ -314,8 +250,8 @@
           <p class="tag">Notes</p>
           <h3>Spacing as Structure</h3>
           <p>
-            White space carries the grid. It is the architecture around the words,
-            not the background behind them.
+            White space carries the grid. It is the architecture around the
+            words, not the background behind them.
           </p>
           <a href="#">Continue reading</a>
         </article>
@@ -323,8 +259,8 @@
           <p class="tag">Essay</p>
           <h3>System Over Ornament</h3>
           <p>
-            A restrained system invites trust: consistent lines, simple rules, and
-            a palette that serves the content.
+            A restrained system invites trust: consistent lines, simple rules,
+            and a palette that serves the content.
           </p>
           <a class="muted-link" href="#">Continue reading</a>
         </article>

--- a/static/style.css
+++ b/static/style.css
@@ -2,20 +2,23 @@
   font-family: "Helvetica Neue", Helvetica, Arial, system-ui, sans-serif;
   color-scheme: light dark;
 
-  --bg: light-dark(#f5f5f2, #1b1d20);
-  --text: light-dark(#1f1f1f, #ededeb);
-  --text-secondary: light-dark(#6b6e73, #a7a9ad);
-  --border: light-dark(#dadada, #34383c);
-  --accent: light-dark(#2f5d8c, #4a78a8);
+  --bg: #f5f5f2;
+  --text: #1f1f1f;
+  --text-secondary: #6b6e73;
+  --border: #dadada;
+  --accent: #2f5d8c;
   --accent-muted: #6b7f5a;
 }
 
-:root[data-theme="light"] {
-  color-scheme: light;
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1b1d20;
+    --text: #ededeb;
+    --text-secondary: #a7a9ad;
+    --border: #34383c;
+    --accent: #4a78a8;
+    --accent-muted: #6b7f5a;
+  }
 }
 
 * {
@@ -147,28 +150,4 @@ p.footer-license {
 
 .muted-link {
   color: var(--accent-muted);
-}
-
-p.theme-selector {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  margin: 0;
-}
-
-p.theme-selector input {
-  display: none;
-}
-
-p.theme-selector label {
-  cursor: pointer;
-  margin: 0;
-  text-decoration: none;
-}
-
-p.theme-selector label:hover {
-  text-decoration: underline;
-}
-
-p.theme-selector input:checked + span {
-  text-decoration: underline;
 }


### PR DESCRIPTION
## Summary

Removes the manual theme switcher and lets the site follow the user's system color scheme.

- Removes the localStorage theme script and footer radio controls from the base layout
- Removes `data-theme` CSS overrides and theme-switcher styles from the main stylesheet
- Applies the same simplification to the standalone reference page

## Validation

- `deno task build`
- `deno check --frozen scripts/build.ts scripts/dev.ts`
- Confirmed generated HTML no longer contains theme-switcher/localStorage/data-theme references